### PR TITLE
Update database.py

### DIFF
--- a/database.py
+++ b/database.py
@@ -288,7 +288,7 @@ def create_tweet_from_dict(tweet, user=None):
         urls = create_urls_from_entities(tweet["entities"])
         mentions = create_users_from_entities(tweet["entities"])
         # Create new database entry for this tweet
-        t = Tweet.create(
+        t, created = Tweet.get_or_create(
             id=tweet['id'],
             user=user,
             text=tweet['text'],


### PR DESCRIPTION
tl;dr:  Fixing a bug, where a "0" was written in the database column "retweet_id" when the original post had already been present in the database.


--_First of all, I want to apologize if this is a rude way to suggest a code edit, I'm really new here and unfamiliar with the conventions._--

This is intented to be a bug fix for the following error I encountered:
Context: I was downloading several user archives for research purposes.
Problem: A bunch of edges were missing in the final retweet graph.
Cause: Several lines in the database contained "0" (zero, not null) in the column "retweed_id". This should never happen, I think.
My interpretation: The function create_tweet_from_dict() returns a 0 when a tweet is already stored in the database. So when it calls itself in line 319 to create the retweeted tweet and this retweeted tweet is already present in the database, "0" is written to the field "retweet"/"retweet_id". This is backed by my observation that not all the retweet_id fields contain zeros and that the zeros can alter when changing the order of downloaded user archives.

The slight code change fixed this issue for me, at least as far as I can tell, but I have no idea whether it creates another error (I'm quite unexperienced at programming).